### PR TITLE
Extend ec2_lc example to demonstrate usage of ephemeral disks.

### DIFF
--- a/cloud/amazon/ec2_lc.py
+++ b/cloud/amazon/ec2_lc.py
@@ -126,6 +126,8 @@ EXAMPLES = '''
       device_type: io1
       iops: 3000
       delete_on_termination: true
+    - device_name: /dev/sdb
+      ephemeral: ephemeral0
 
 '''
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

ec2_lc
##### ANSIBLE VERSION

n/a (docs change)
##### SUMMARY

Current docs mention that ephemeral disks can be added in the volumes array but it's not clear how without reference to google or the code. This example makes it clear, saving time for users.
